### PR TITLE
Instructor Dashboard View Changes

### DIFF
--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -524,9 +524,9 @@
     };
 
 	$.DashboardView.prototype.displayReplies = function(replies_unsorted) {
-        var replies = self.sortAnnotationsByCreated(replies_unsorted);
 		var self = this;
-        var replies_offset = jQuery('.parentAnnotation').offset().top -jQuery('.annotationModal').offset().top + jQuery('.parentAnnotation').height();
+		var replies = self.sortAnnotationsByCreated(replies_unsorted);
+		var replies_offset = jQuery('.parentAnnotation').offset().top -jQuery('.annotationModal').offset().top + jQuery('.parentAnnotation').height();
 		var replies_height = jQuery(window).height() - jQuery('.replybutton').height() - jQuery('.parentAnnotation').height() - jQuery('.modal-navigation').height();
 		jQuery('.repliesList').css('margin-top', replies_offset);
 		jQuery('.repliesList').css('height', replies_height);

--- a/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
+++ b/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
@@ -85,15 +85,12 @@ def assignment_object_exists(object_id, collection_id):
 		return False
 
 @register.simple_tag
-def get_annotation_by_id(id, annotations):
+def get_annotation_by_id(annotation_id, annotations):
 	'''
 		Given the id of an annotation and a dictionary of annotations keyed by id,
 		this returns the text of the annotation with that id	
 	'''
-	
-	try:
-		annotation = annotations[id]["text"]
-	except:
-		annotation = "<i>Deleted Annotation</i>"
-	
-	return annotation
+	annotation_id = int(annotation_id)
+	if annotation_id in annotations:
+		return annotations[annotation_id]['text']
+	return '<i>Deleted Annotation</i>'

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -210,7 +210,7 @@ def fetch_annotations_by_course(context_id, token):
     request_start_time = time.clock()
     r = requests.get(request_url, headers=headers)
     request_end_time = time.clock()
-    request_elapsed_time = request_end_time - request_end_time
+    request_elapsed_time = request_end_time - request_start_time
 
     debug_printer("DEBUG - fetch_annotations_by_course(): annotation database response code: %s" % r.status_code)
     debug_printer("DEBUG - fetch_annotations_by_course(): request time elapsed: %s seconds" % (request_elapsed_time))

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -10,8 +10,10 @@ from django.conf import settings
 from ims_lti_py.tool_provider import DjangoToolProvider
 import base64
 import sys
+import time
 import datetime
 import jwt
+import requests
 
 # import Sample Target Object Model
 from target_object_database.models import TargetObject
@@ -188,3 +190,93 @@ class simple_utc(datetime.tzinfo):
 
     def utcoffset(self, dt):
         return datetime.timedelta(0)
+
+
+def fetch_annotations_by_course(context_id, token):
+    '''
+    Fetches the annotations of a given course from the CATCH database
+    '''
+    # build request
+    headers = {
+        "x-annotator-auth-token": token,
+        "Content-Type":"application/json"
+    }
+    limit = 10000 #TODO: How do we want to handle this?
+    request_url = "%s/search?contextId=%s&limit=%s" % (settings.ANNOTATION_DB_URL, context_id, limit)
+
+    debug_printer("DEBUG - fetch_annotations_by_course(): url: %s" % request_url)
+
+    # make request
+    request_start_time = time.clock()
+    r = requests.get(request_url, headers=headers)
+    request_end_time = time.clock()
+    request_elapsed_time = request_end_time - request_end_time
+
+    debug_printer("DEBUG - fetch_annotations_by_course(): annotation database response code: %s" % r.status_code)
+    debug_printer("DEBUG - fetch_annotations_by_course(): request time elapsed: %s seconds" % (request_elapsed_time))
+
+    try:
+        # this gets the whole request, including such things as 'count'
+        # however, that also means that the annotations come in as an object called 'rows,'
+        # where each row represents an annotation object.
+        # if more convenient, we could cut the top level and just return flat annotations.
+        annotations = r.json()
+        
+    except:
+        # If there are no annotations, the database should return a dictionary with empty rows,
+        # but in the event of another exception such as an authentication error, fail
+        # gracefully by manually passing in that empty response
+        annotations = {'rows':[]}
+        logging.error('Error decoding JSON from CATCH. Check to see if authentication is correctly configured')
+
+    return annotations
+
+def get_distinct_users_from_annotations(annotations):
+    '''
+    Given a set of annotation objects returned by the CATCH database,
+    this function returns a list of distinct user objects.
+    '''
+    rows = annotations['rows']
+    annotations_by_user = {}
+    for r in rows:
+        user_id = r['user']['id']
+        if user_id not in annotations_by_user:
+            annotations_by_user[user_id] = r['user']
+    users = list(sorted(annotations_by_user.values(), key=lambda user: user['id']))
+    return users
+
+def get_annotations_for_user_id(annotations, user_id):
+    '''
+    Given a set of annotation objects returned by the CATCH database
+    and an user ID, this functino returns all of the annotations
+    for that user.
+    '''
+    rows = annotations['rows']
+    return [r for r in rows if r['user']['id'] == user_id]
+
+def get_annotations_keyed_by_user_id(annotations):
+    '''
+    Given a set of annotation objects returned by the CATCH database,
+    this function returns a dictionary that maps user IDs to annotation objects.
+    '''
+    rows = annotations['rows']
+    annotations_by_user = {}
+    for r in rows:
+        user_id = r['user']['id']
+        annotations_by_user.setdefault(user_id, []).append(r)
+    return annotations_by_user
+
+def get_annotations_keyed_by_annotation_id(annotations):
+    '''
+    Given a set of annotation objects returned by the CATCH database,
+    this function returns a dictionary that maps annotation IDs to
+    annotation objects.
+    
+    The intended usage is for when you have an annotation that is a
+    reply to another annotation, and you want to lookup the parent
+    annotatino by its ID.
+    '''
+    rows = annotations['rows']
+    return dict([(r['id'], r) for r in rows])
+    
+

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -22,15 +22,20 @@
 		jQuery('#id_target_content').summernote(options);
 		
 		// Autopopulate creator and course in target form
-		// Get name of creator and course
-		var creatorName = "{{ creator | safe }}";
-        var courseId = "{{ course | safe }}";
-        // Get values of options matching the creator name and course name
-        var creatorValue = $('#id_target_creator option').filter(function () { return $(this).text() == creatorName;}).val();
-        var courseValue = $('#id_target_courses option').filter(function () { return $(this).val() == courseId;}).val();
-        // Set current creator and current course as defaults in selectors
-        $('select[name=target_creator]').val(creatorValue);
-        $('select[name=target_courses]').val(courseValue);
+		var creatorId = "{{ creator | safe }}";
+		var courseId = "{{ course | safe }}";
+		var equals_option_value = function(val) {
+			return function() {
+				return $(this).val() == val;
+			};
+		};
+
+		var creatorValue = $('#id_target_creator option').filter(equals_option_value(creatorId)).val();
+		var courseValue = $('#id_target_courses option').filter(equals_option_value(courseId)).val();
+
+		// Set current creator and current course as defaults in selectors
+		$('select[name=target_creator]').val(creatorValue);
+		$('select[name=target_courses]').val(courseValue);
 		$('.selectpicker').selectpicker('refresh');
 	});
 

--- a/target_object_database/views.py
+++ b/target_object_database/views.py
@@ -12,6 +12,10 @@ from rest_framework import generics
 def get_course_id(request):
 	return request.session['hx_lti_course_id']
 
+def get_lti_profile_id(request):
+    lti_profile = LTIProfile.objects.get(user=request.user)
+    return lti_profile.id
+
 def open_target_object(request, collection_id, target_obj_id):
     try:
         targ_obj = TargetObject.objects.get(pk=target_obj_id)
@@ -73,7 +77,7 @@ def edit_source(request, id):
         {
             'form': form,
             'user': request.user,
-            'creator': request.session['creator_default'],
+            'creator': get_lti_profile_id(request),
             'course': get_course_id(request),
         }
     )
@@ -95,7 +99,7 @@ def handlePopAdd(request, addForm, field):
         'form': form,
         'field': field,
         'user': request.user,
-        'creator': request.session['creator_default'],
+        'creator': get_lti_profile_id(request),
         'course': get_course_id(request),
     }
     return render_to_response(


### PR DESCRIPTION
This PR refactors the instructor dashboard view to only depend on the CATCH for retrieving user/annotation info. I've moved all of the helper methods into the ```hx_lti_initializer.utils``` module.

Note: the *limit* search parameter is still hard coded to return a maximum of 10,000 annotations. We'll have to address this at some point, although for ATG's purposes it should be more than enough.

@lduarte1991 Thoughts?