### PR TITLE
Fixed user name on assignment and source material pages

### DIFF
--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -61,7 +61,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'annotationsx.middleware.XFrameOptionsMiddleware',
-    #django'django_auth_lti.middleware.LTIAuthMiddleware',
+    #'django_auth_lti.middleware.LTIAuthMiddleware',
     # 'django_auth_lti.middleware_patched.MultiLTILaunchAuthMiddleware'
 )
 
@@ -122,27 +122,6 @@ JENKINS_TASKS = (
     'django_jenkins.tasks.run_pep8',
     'django_jenkins.tasks.run_pylint',
 )
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'loggers': {
-        '': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-        'django': {
-            'handlers': ['console'],
-            'level': 'INFO',
-        },
-    },
-}
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"
 

--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -61,7 +61,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'annotationsx.middleware.XFrameOptionsMiddleware',
-    #'django_auth_lti.middleware.LTIAuthMiddleware',
+    #django'django_auth_lti.middleware.LTIAuthMiddleware',
     # 'django_auth_lti.middleware_patched.MultiLTILaunchAuthMiddleware'
 )
 
@@ -122,6 +122,27 @@ JENKINS_TASKS = (
     'django_jenkins.tasks.run_pep8',
     'django_jenkins.tasks.run_pylint',
 )
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'django': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        },
+    },
+}
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"
 

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment.html
@@ -284,8 +284,7 @@
 							</select>
 							<div class="collapse" id="assignment-target-object-settings-{{forloop.counter0}}">
 								<label for="id_assignmenttargets_set-{{forloop.counter0}}-target_instructions">Instructions:</label> 
-					}
-					}
+
 			<textarea id="id_assignmenttargets_set-{{forloop.counter0}}-target_instructions" name="assignmenttargets_set-{{forloop.counter0}}-target_instructions" class="form-control">{{ item.target_instructions.value }}</textarea>
 								<label for="id_assignmenttargets_set-{{forloop.counter0}}-target_external_css">Assignment CSS:</label> 
 			<input id="id_assignmenttargets_set-{{forloop.counter0}}-target_external_css" maxlength="255" name="assignmenttargets_set-{{forloop.counter0}}-target_external_css" class="form-control" type="text" value="{{ item.target_external_css.value }}">

--- a/hx_lti_assignment/views.py
+++ b/hx_lti_assignment/views.py
@@ -54,7 +54,7 @@ def create_new_assignment(request):
                     {
                         'form': form,
                         'targets_form': targets_form,
-                        'user': request.user,
+                        'username': request.session['hx_user_name'],
                         'number_of_targets': target_num,
                         'debug': debug,
                         'course_id': get_course_id(request),
@@ -97,7 +97,7 @@ def create_new_assignment(request):
         {
             'form': form,
             'targets_form': targets_form,
-            'user': request.user,
+            'username': request.session['hx_user_name'],
             'number_of_targets': target_num,
             'debug': debug,
             'course_id': get_course_id(request),
@@ -153,7 +153,7 @@ def edit_assignment(request, id):
                     {
                         'form': form,
                         'targets_form': targets_form,
-                        'user': request.user,
+                        'username': request.session['hx_user_name'],
                         'number_of_targets': target_num,
                         'debug': debug,
                         'course_id': get_course_id(request),
@@ -175,7 +175,7 @@ def edit_assignment(request, id):
             'form': form,
             'targets_form': targets_form,
             'number_of_targets': target_num,
-            'user': request.user,
+            'username': request.session['hx_user_name'],
             'debug': debug,
             'assignment_id': assignment.assignment_id,
             'course_id': get_course_id(request),

--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
@@ -1,35 +1,18 @@
-<!-- TODO: base template? Any common html that can be factored out. -->
-<!-- Load static? -->
+{% extends 'hx_lti_initializer/base.html' %}
 {% load hx_lti_initializer_extras %}
+{% load static from staticfiles %} 
+{# Load the tag library #} 
+{% load bootstrap3 %} 
+{# Load CSS and JavaScript #} 
+{% bootstrap_css %} 
+{% bootstrap_javascript %} 
+{# Display django.contrib.messages as Bootstrap alerts #} 
+{% bootstrap_messages %}
 
-<html lang="en">
 
-    <head>
-        <meta charset="UTF-8">
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-
-        <!-- TODO: is this staticfiles or http_static? -->
-        {% load static from staticfiles %} 
-        {# Load the tag library #} 
-        {% load bootstrap3 %} 
-        {# Load CSS and JavaScript #} 
-        {% bootstrap_css %} 
-        {% bootstrap_javascript %} 
-        {# Display django.contrib.messages as Bootstrap alerts #} 
-        {% bootstrap_messages %}
-        
-        <title>Instructor Dashboard</title>
-    </head>
-
-    <body>
-        <br/>
-        <div class="container">
-        <div class="navigation">
-                <a href="{% url 'hx_lti_initializer:course_admin_hub' %}">Home</a>
-        </div>
-        <br>
+{% block content %}
         {% if user_objects %}
-            <div>
+            <div style="margin: 1em 0;">
                 <div class="input-group">
                     <div class="input-group-btn search-panel">
                         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
@@ -111,10 +94,6 @@
                 {% else %}
                 No annotations to display
             </div>
-        {% endif %}
-        </div>
-    </body>
-</html>
 
 <script>
 $(document).ready(function(){
@@ -175,3 +154,5 @@ $(document).ready(function(){
     }
 });
 </script>
+        {% endif %}
+{% endblock %}

--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
@@ -94,7 +94,7 @@
                 {% else %}
                 No annotations to display
             </div>
-
+		{% endif %}
 <script>
 $(document).ready(function(){
     // Search type (name by default)
@@ -154,5 +154,4 @@ $(document).ready(function(){
     }
 });
 </script>
-        {% endif %}
 {% endblock %}

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -367,6 +367,8 @@ def instructor_dashboard_view(request):
     user_objects = list(sorted(user_objects, key=lambda user: user['name'].lower()))
 
     context = {
+        'username': request.session['hx_user_name'],
+        'is_instructor': request.session["is_staff"],
         'user_objects': user_objects, # user objects with their associated annotations
         'annotation_dict': annotations_by_anno, # annotations keyed by id for easy reply lookup
     }

--- a/target_object_database/views.py
+++ b/target_object_database/views.py
@@ -49,7 +49,7 @@ def create_new_source(request):
         'target_object_database/source_form.html',
         {
             'form': form,
-            'user': request.user,
+            'username': request.session['hx_user_name'],
         }
     )
 
@@ -76,7 +76,7 @@ def edit_source(request, id):
         'target_object_database/source_form.html',
         {
             'form': form,
-            'user': request.user,
+            'username': request.session['hx_user_name'],
             'creator': get_lti_profile_id(request),
             'course': get_course_id(request),
         }
@@ -98,7 +98,7 @@ def handlePopAdd(request, addForm, field):
     pageContext = {
         'form': form,
         'field': field,
-        'user': request.user,
+        'username': request.session['hx_user_name'],
         'creator': get_lti_profile_id(request),
         'course': get_course_id(request),
     }


### PR DESCRIPTION
This PR fixes the user name on the *create assignment* and *create source* pages, which were trying to get the user's name from the *request.user* object. I changed it to get the value from the session. I also modified the instructor dashboard template so that it extends the base template and feels integrated with the app. 

What do you think @lduarte1991?