### PR TITLE
Manual URL setting

### DIFF
--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -157,11 +157,13 @@ LTI_SETUP = {
     }
 }
 
+ANNOTATION_MANUAL_URL = None
 ANNOTATION_DB_URL = SECURE_SETTINGS.get("annotation_database_url")
 ANNOTATION_DB_API_KEY = SECURE_SETTINGS.get("annotation_db_api_key")
 ANNOTATION_DB_SECRET_TOKEN = SECURE_SETTINGS.get("annotation_db_secret_token")
 
 if ORGANIZATION == "ATG":
+    ANNOTATION_MANUAL_URL = SECURE_SETTINGS["annotation_manual_url"]
     LTI_OAUTH_CREDENTIALS = SECURE_SETTINGS['lti_oauth_credentials']
     CONSUMER_KEY = LTI_OAUTH_CREDENTIALS.items()[0][0]
     LTI_SECRET = LTI_OAUTH_CREDENTIALS.items()[0][1]

--- a/hx_lti_initializer/templates/hx_lti_initializer/base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/base.html
@@ -33,7 +33,7 @@
         <nav class="navigation" role="navigation" aria-label="Main Menu">
             <a href="{% url 'hx_lti_initializer:course_admin_hub' %}">Home</a>
             {% if is_instructor %}
-            <a href="{% static "pages/instructor_manual/hxat-instructor-manual.html"%}">Manual</a>
+            <a href="{% get_url_to_annotation_manual default="pages/instructor_manual/hxat-instructor-manual.html" %}">Manual</a>
             <a role="button" href="instructor_dashboard_view">Instructor Dashboard</a>
             {% endif %}
         </nav>

--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
@@ -94,7 +94,7 @@
                 {% else %}
                 No annotations to display
             </div>
-
+		{% endif %}
 <script>
 $(document).ready(function(){
     // Search type (name by default)
@@ -154,5 +154,4 @@ $(document).ready(function(){
     }
 });
 </script>
-        {% endif %}
 {% endblock %}

--- a/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
+++ b/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
@@ -1,9 +1,10 @@
 from django.template.defaulttags import register
-
+from django.conf import settings
 from datetime import datetime
 from dateutil import tz
 from django import template
 from django.template.defaultfilters import stringfilter
+from django.contrib.staticfiles.templatetags.staticfiles import static
 from re import sub
 
 from hx_lti_assignment.models import Assignment
@@ -94,3 +95,17 @@ def get_annotation_by_id(annotation_id, annotations):
 	if annotation_id in annotations:
 		return annotations[annotation_id]['text']
 	return '<i>Deleted Annotation</i>'
+
+@register.simple_tag
+def get_url_to_annotation_manual(**kwargs):
+	'''
+	Returns the URL to the annotation manual. When the URL is present in the django settings,
+	it returns this URL, otherwise it will return the static url passed in to this function.
+	'''
+	url = kwargs.get('default', '')
+	if settings.ANNOTATION_MANUAL_URL is not None:
+		url = settings.ANNOTATION_MANUAL_URL
+	if not url.startswith('http'):
+		url = static(url)
+	return url
+	


### PR DESCRIPTION
This adds the ability to modify the **Manual** link on the admin hub. It defaults to the HarvardX manual page. See also https://github.com/Harvard-ATG/annotationsx/pull/40