### PR TITLE
Fixed issue with null target_external_options and annotation_database_search

### DIFF
--- a/hx_lti_assignment/models.py
+++ b/hx_lti_assignment/models.py
@@ -39,10 +39,25 @@ class AssignmentTargets(models.Model):
             'order',
         ]
 
+    def get_target_external_options_list(self):
+        """
+        Returns a list of options that are saved to the target_external_options model attribute
+        in CSV format.
+        
+        Notes:
+        - since the model attribute could be null in the database, we have to
+          check if it's None before trying parse it.
+        - this field does not contain user-supplied values, so we don't need industrial-strength
+          CSV parsing.
+        """
+        if self.target_external_options is None:
+            return []
+        return self.target_external_options.split(',')    
+
     def get_view_type_for_mirador(self):
         """
         """
-        options = self.target_external_options.split(',')
+        options = self.get_target_external_options_list()
         if len(options) == 1:
             return "ImageView"
         else:
@@ -51,7 +66,7 @@ class AssignmentTargets(models.Model):
     def get_canvas_id_for_mirador(self):
         """
         """
-        options = self.target_external_options.split(',')
+        options = self.get_target_external_options_list()
         if len(options) == 1:
             return None
         else:
@@ -60,7 +75,7 @@ class AssignmentTargets(models.Model):
     def get_dashboard_hidden(self):
         """
         """
-        options = self.target_external_options.split(',')
+        options = self.get_target_external_options_list()
         if len(options) < 3:
             return "false"
         else:

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -417,6 +417,20 @@ def delete_assignment(request):
 
 
 def annotation_database_search(request):
+    '''
+    This view is intended to be called by the annotation dashboard when searching
+    the CATCH database for annotations.
+    
+    It's essentially a proxy for annotatorJS requests, with a permission check to
+    make sure the user is authorized to search the given course and collection.
+    
+    Required GET parameters:
+     - collectionId: this is the assignment model
+     - contextId: this is the course identifier as defined by LTI (the "course context")
+    
+    The optional GET parameters include those specified by the CATCH database as
+    search fields.
+    '''
     session_collection_id = request.session['hx_collection_id']
     session_context_id = request.session['hx_context_id']
 

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -418,20 +418,17 @@ def delete_assignment(request):
 
 def annotation_database_search(request):
     session_collection_id = request.session['hx_collection_id']
-    session_object_id = request.session['hx_object_id']
     session_context_id = request.session['hx_context_id']
 
-    request_collection_id = request.GET['collectionId']
-    request_object_id = request.GET['uri']
-    request_context_id = request.GET['contextId']
+    request_collection_id = request.GET.get('collectionId', None)
+    request_context_id = request.GET.get('contextId', None)
 
     # verifies the query against session so they can't get unauthorized items
     if (session_collection_id != request_collection_id or
             session_context_id != request_context_id):
         return HttpResponse("You are not authorized to search for annotations")
 
-    collection_id = request.GET['collectionId']
-    assignment = get_object_or_404(Assignment, assignment_id=collection_id)
+    assignment = get_object_or_404(Assignment, assignment_id=request_collection_id)
 
     url_values = request.GET.urlencode()
     database_url = str(assignment.annotation_database_url).strip() + '/search?'


### PR DESCRIPTION
This fixes an issue that arises when the ```AssignmentTargets.target_external_options``` are null in the database. The issue came up when I deployed the code to our STAGE server (after running the migration). It looks like the field was set to null for the existing assignments, but the code assumed the value of the field would always be an empty string. I changed the code to use a getter method instead of retrieving the field directly, that way the logic for checking the field value and parsing it is in one place. 

This also fixes an issue on image annotations that came up when the search query did not include a ```uri``` parameter (it was hard failing on the ```request.GET['uri']``` line). 

@lduarte1991 Thoughts?