### PR TITLE
Merge candidate

### DIFF
--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
@@ -32,12 +32,12 @@
 			<div>
 				<div class="panel-group" id="accordion">
 					<div class="panel panel-default">
-						<div data-toggle="collapse" data-parent="#accordion" href="#{{ user.id }}" class="panel-heading list-group-item" style="cursor: pointer;">
+						<div data-toggle="collapse" data-parent="#accordion" href="#userpanel-{{ forloop.counter }}" class="panel-heading list-group-item" style="cursor: pointer;">
 							<h4 class="panel-title">
 								{{ user.name }} ({{user.total_annotations}})
 							</h4>
 						</div>
-						<div id="{{ user.id }}" class="panel-collapse collapse">
+						<div id="userpanel-{{ forloop.counter }}" class="panel-collapse collapse">
 							<div class="panel-body">
 									<table class="table table-hover">
 									<thead>


### PR DESCRIPTION
@lduarte1991 this PR should fix the issue on the instructor dashboard when a ```user_id``` contains an email address. Since there's no real need to use ```user_id``` to identify the collapsible panels on the page, I replaced ```user_id``` with the forloop counter (i.e. an arbitrary ID).