### PR TITLE
Instructor dashboard change: get annotation database settings from assignments

### DIFF
--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -448,7 +448,7 @@ class DashboardAnnotations(object):
         return ''
     
     def get_target_object_name(self, annotation):
-        media_type = annotation['media']
+        media_type = annotation.get('media', None)
         object_id = annotation['uri']
         target_id = self.get_target_id(media_type, object_id)
         if target_id in self.target_objects_by_id:
@@ -457,7 +457,7 @@ class DashboardAnnotations(object):
 
     def get_target_preview_url(self, annotation):
         annotation_id = annotation['id']
-        media_type = annotation['media']
+        media_type = annotation.get('media', None)
         context_id = annotation['contextId']
         collection_id = annotation['collectionId']
         url_format = "%s?focus_on_id=%s"
@@ -482,7 +482,7 @@ class DashboardAnnotations(object):
         return preview_url
     
     def assignment_object_exists(self, annotation):
-        media_type = annotation['media']
+        media_type = annotation.get('media', None)
         collection_id = annotation['collectionId']
         object_id = annotation['uri']
         target_id = self.get_target_id(media_type, object_id)

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -201,13 +201,14 @@ class simple_utc(datetime.tzinfo):
 def get_annotation_db_credentials_by_course(context_id):
     '''
     Returns the distinct set of annotation database credentials (url, api key, secret token)
-    for a given course. Recall that these credentials are stored on a per-assignment basis.
-    In most cases, the credentials will be the same across all assignments in a course, so
-    we would usually expect to *one* result (url, api key, secret token), but it's possible
-    to receive more if the values have been manually changed.
-    
+    for a given course.
+
+    The credentials are stored on a per-assignment basis, and a course will have many assignments.
+    The expected use case is that *one* credential (url, api key, secret token) will be
+    used across all assignments in a course, but it's possible that might not be the case.
+
     Returns:
-    
+
     [
         {
             'annotation_database_url': 'http://catch-database.localhost/catch/annotator',
@@ -215,7 +216,7 @@ def get_annotation_db_credentials_by_course(context_id):
             'annotation_database_secret_token': u'GWoXMgXkprYL4ZtkELyq',
         },
         {
-            'annotation_database_url': 'https://another-catch.localhost/catch/annotator',
+            'annotation_database_url': 'https://catch-database.localhost/catch/annotator',
             'annotation_database_apikey': '069fK9KTLHugO7uxjfwN',
             'annotation_database_secret_token': 'Xbi791aSsF4AVWjMhQnl',
         }

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -490,7 +490,7 @@ class DashboardAnnotations(object):
 
     def get_annotation_parent_value(self, annotation, attr):
         parent_value = None
-        if annotation['parent']:
+        if 'parent' in annotation and annotation['parent']:
             parent_id = annotation['parent']
             parent_annotation = self.get_annotation_by_id(parent_id)
             if parent_annotation is not None and attr in parent_annotation:

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -350,21 +350,21 @@ def instructor_dashboard_view(request):
     '''
         Renders the instructor dashboard
     '''
-    # Check permission
+    # Check permissions
     if not request.session['is_staff']:
         raise PermissionDenied("You must be a staff member to view the dashboard.")
-
+    
     # Get all the relevant objects we're going to need for the dashboard
-    user_id = request.session['hx_user_id']
     context_id = request.session['hx_context_id']
-    course_object = LTICourse.objects.get(course_id=context_id)
-    token = retrieve_token(user_id, settings.ANNOTATION_DB_API_KEY, settings.ANNOTATION_DB_SECRET_TOKEN)
-        
+    user_id = request.session['hx_user_id']
+    
+    # Fetch the annotations and time how long the request takes
     fetch_start_time = time.time()
-    course_annotations = fetch_annotations_by_course(context_id, token)
+    course_annotations = fetch_annotations_by_course(context_id, user_id)
     fetch_end_time = time.time()
     fetch_elapsed_time = fetch_end_time - fetch_start_time
 
+    # Transform the raw annotation results into something useful for the dashboard
     user_annotations = DashboardAnnotations(course_annotations).get_annotations_by_user()
 
     context = {


### PR DESCRIPTION
This PR fixes an issue I encountered in our stage environment, where we apparently had different annotation db settings on some assignments, resulting in some annotations not being shown on the dashboard (probably because we'd been transitioning catch servers a while back). 

So this PR fixes that so that the instructor dashboard gets the annotation database settings from the assignment models, rather than from the globally defined secure settings. This PR also includes a few bug fixes also identified in testing such as:

- The *media* attribute is not always present on annotations.
- The *parent* attribute is not always present on annotations.

I'm not sure if those are guaranteed to be there on new annotations, but I came across a few cases where old annotations did not have those attributes and it broke the dashboard.