### PR TITLE
default_pagination_limit

### DIFF
--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -190,6 +190,7 @@ ANNOTATION_MANUAL_URL = None
 ANNOTATION_DB_URL = SECURE_SETTINGS.get("annotation_database_url")
 ANNOTATION_DB_API_KEY = SECURE_SETTINGS.get("annotation_db_api_key")
 ANNOTATION_DB_SECRET_TOKEN = SECURE_SETTINGS.get("annotation_db_secret_token")
+ANNOTATION_PAGINATION_LIMIT_DEFAULT = SECURE_SETTINGS.get("annotation_pagination_limit_default", 20)
 
 if ORGANIZATION == "ATG":
     ANNOTATION_MANUAL_URL = SECURE_SETTINGS["annotation_manual_url"]

--- a/hx_lti_assignment/views.py
+++ b/hx_lti_assignment/views.py
@@ -85,8 +85,7 @@ def create_new_assignment(request):
                 'annotation_database_url': getattr(settings, 'ANNOTATION_DB_URL', ""),
 	            'annotation_database_apikey': getattr(settings, 'ANNOTATION_DB_API_KEY', ""),
 	            'annotation_database_secret_token': getattr(settings, 'ANNOTATION_DB_SECRET_TOKEN', ""),
-	            # TODO: Figure out a sensible default
-	            'pagination_limit': 20,
+	            'pagination_limit': getattr(settings, 'ANNOTATION_PAGINATION_LIMIT_DEFAULT', 20),
             })
         targets_form = AssignmentTargetsFormSet()
         target_num = 0


### PR DESCRIPTION
This PR adds the ability to configure the default pagination limit from the environment settings (i.e. secure settings), so that different environments can set an appropriate default. This setting will populate the assignment form as the default, but of course, the instructor/admin can change it. The existing default is 20, so if no value is provided that will remain the default. 
 
Note: this was motivated by an issue we noticed with paginated text annotations (>20 annotations per text). We noticed that instead of loading the first page of annotations according to the order in which they appear in the text, it loads later annotations first. This leaves the user confused as to why the early part of the text doesn't show their annotations and no indication is given that they need to scroll to load them. The workaround is to simply increase the pagination limit, which is what this PR is focused on.

@lduarte1991 Does this look OK? 