### PR TITLE
Re-enable django_app_lti XML config

### DIFF
--- a/annotationsx/urls.py
+++ b/annotationsx/urls.py
@@ -17,5 +17,5 @@ urlpatterns = patterns('',
     url(r'^500/', TemplateView.as_view(template_name="500.html")),
     # TODO: Check to see if this works without enabling django_app_lti
     # Include the lti app's urls
-    #url(r'^lti/', include(django_app_lti.urls, namespace="lti")),
+    url(r'^lti/', include(django_app_lti.urls, namespace="lti")),
 )


### PR DESCRIPTION
This PR re-enables the url for the LTI xml config provided by ```django_app_lti```. We use the xml config output to install the tool in Canvas. This shouldn't impact anything since it was already in the INSTALLED_APPS.