### PR TITLE
chore: bump requirements for python 3.12

### DIFF
--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -15,6 +15,7 @@ PyJWT==2.4.0
 python-dateutil==2.8.1
 pytz==2019.3
 requests==2.32.3
+urllib3==2.3.0
 python_dotenv==0.14.0
 WhiteNoise==5.2.0
 git+https://github.com/Harvard-ATG/media_management_sdk.git@v0.2.0#egg=media_management_sdk==0.2.0

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -10,7 +10,7 @@ django-extensions==2.2.8
 django-log-request-id==2.0.0
 djangorestframework==3.11.2
 lti==0.9.5
-psycopg2-binary==2.8.4
+psycopg2-binary==2.9.10
 PyJWT==2.4.0
 python-dateutil==2.8.1
 pytz==2019.3

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -14,7 +14,7 @@ psycopg2-binary==2.9.10
 PyJWT==2.4.0
 python-dateutil==2.8.1
 pytz==2019.3
-requests==2.23.0
+requests==2.32.3
 python_dotenv==0.14.0
 WhiteNoise==5.2.0
 git+https://github.com/Harvard-ATG/media_management_sdk.git@v0.2.0#egg=media_management_sdk==0.2.0


### PR DESCRIPTION
Bump minimum requirements need to run with python 3.12 on Ubuntu LTS 22.04

Private Ref: [BB-9443](https://tasks.opencraft.com/browse/BB-9443)